### PR TITLE
fix: Call `nextConfig.webpack` function.

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,4 +21,21 @@ describe('withPrismaPlugin', () => {
     const newConfig = withPrismaPlugin(nextConfig)('phase-development-server', {})
     expect(newConfig).toHaveProperty('webpack')
   })
+
+  it('should call nextConfig function and add webpack property', () => {
+    const nextConfig = () => ({ foo: 'bar' })
+
+    const newConfig = withPrismaPlugin(nextConfig)('phase-development-server', {})
+    expect(newConfig).toHaveProperty('webpack')
+  })
+
+  it('should call nextConfig.webpack function', () => {
+    const nextConfig = () => ({ webpack: (config: {}) => ({ ...config, foo: 'bar' }) })
+
+    const newConfig = withPrismaPlugin(nextConfig)('phase-development-server', {})
+    expect(newConfig).toHaveProperty('webpack')
+    expect(newConfig.webpack({ plugins: [], watchOptions: { ignored: [] } })).toMatchObject({
+      foo: 'bar',
+    })
+  })
 })


### PR DESCRIPTION
I've tried to mix this plugin with the [@next/mdx](https://www.npmjs.com/package/@next/mdx) and could not make it work, e.g:
```js
const makeWithMDX = require("@next/mdx");
const withPrismaPlugin = require("next-prisma-plugin");

const withMDX = makeWithMDX({
  extension: /\.mdx?$/,
});

module.exports = withPrismaPlugin(
  withMDX({
    pageExtensions: ["tsx", "ts", "mdx", "md"],
  });
);
```

Then I've checked the source code of the `withMDX` and found that it's changing `webpack`  property, but `next-prisma-plugin` does not check if `webpack` property was passed or not.

PS: This workaround is working, but not ideal:

```js
const makeWithMDX = require("@next/mdx");
const makeWithPrismaPlugin = require("next-prisma-plugin");

const withMDX = makeWithMDX({
  extension: /\.mdx?$/,
});

const withPrismaPlugin = makeWithPrismaPlugin();

module.exports = (phase, thing) => {
  const prismaConfig = withPrismaPlugin(phase, thing);
  const mdxConfig = withMDX(prismaConfig);

  return {
    ...mdxConfig,
    pageExtensions: ["tsx", "ts", "mdx", "md"],
  };
};
```
