### PR TITLE
Fix: Convert the RegExp to a string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const withPrismaPlugin = (nextConfig = {}) => (
         const ignore = ['.prisma/client', '@prisma/client']
 
         // const includes = ignore.map(module => (new RegExp(`${module}(?!.*node_modules)`)));
-        const excludes = [new RegExp(`node_modules(?!/(${ignore.join('|')})(?!.*node_modules))`)]
+        const excludes = [new RegExp(`node_modules(?!/(${ignore.join('|')})(?!.*node_modules))`).toString()]
         const ignored = config.watchOptions.ignored
           .filter((ignored: string) => ignored !== '**/node_modules/**')
           .concat(excludes)


### PR DESCRIPTION
By converting the `RegExp` to a `string` webpack stops complaining. I've done some quick testing and it seem that everything is still working, but I would love some other eyes on this.

Because webpack converts `globs` to `RegExp` it seems that it executes this `RegExp` that is just a sting. (https://webpack.js.org/configuration/watch/#watchoptionsignored)

This closes #31 